### PR TITLE
version 1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<center>
+<div style="text-align: center;">
   
 **Download latest**<br>
 &nbsp;&nbsp;[![GitHub Stable](
@@ -15,7 +15,7 @@
 ![Downloads](https://img.shields.io/github/downloads/wandomium/SmsLoc/total)
 
 ---
-</center>
+</div>
 
 # About
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "io.github.wandomium.smsloc"
         minSdk 29
         targetSdk 35
-        versionCode 115
-        versionName "1.1.5"
+        versionCode 116
+        versionName "1.1.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         applicationId "io.github.wandomium.smsloc"
         minSdk 29
         targetSdk 35
-        versionCode 116
-        versionName "1.1.6"
+        versionCode 120
+        versionName "1.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -56,17 +56,17 @@ dependencies {
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
-    implementation 'androidx.navigation:navigation-fragment:2.9.3'
-    implementation 'androidx.navigation:navigation-ui:2.9.3'
+    implementation 'androidx.navigation:navigation-fragment:2.9.5'
+    implementation 'androidx.navigation:navigation-ui:2.9.5'
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.2.0-beta01"
     implementation "androidx.lifecycle:lifecycle-extensions:2.2.0"
-    implementation 'androidx.work:work-runtime:2.10.3'
+    implementation 'androidx.work:work-runtime:2.10.5'
     
     implementation 'org.osmdroid:osmdroid-android:6.1.20'
 
-    implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.3'
-    implementation 'com.google.android.material:material:1.12.0'
-    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'com.googlecode.libphonenumber:libphonenumber:9.0.15'
+    implementation 'com.google.android.material:material:1.13.0'
+    implementation 'com.google.code.gson:gson:2.13.2'
 
 //    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
 //    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -91,6 +91,7 @@ along with SmsLoc. If not, see <https://www.gnu.org/licenses/>.
                 <action android:name="android.provider.Telephony.SMS_RECEIVED" />
             </intent-filter>
         </receiver>
+        <receiver android:name="io.github.wandomium.smsloc.SmsSentReceiver" />
         <receiver
             android:name="io.github.wandomium.smsloc.BootReceiver"
             android:enabled="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -54,6 +54,17 @@ along with SmsLoc. If not, see <https://www.gnu.org/licenses/>.
         android:required="true"
         tools:ignore="UnnecessaryRequiredFeature" />
 
+    <!-- Used to try and open background autostart settings on custom ROMs -->
+    <queries>
+        <package android:name="com.miui.securitycenter" />
+        <package android:name="com.coloros.safecenter" />
+        <package android:name="com.oppo.safe" />
+        <package android:name="com.vivo.permissionmanager" />
+        <package android:name="com.iqoo.secure" />
+        <package android:name="com.huawei.systemmanager" />
+        <package android:name="com.letv.android.letvsafe" />
+        <package android:name="com.asus.mobilemanager" />
+    </queries>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/io/github/wandomium/smsloc/LocationRetriever.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/LocationRetriever.java
@@ -73,7 +73,14 @@ public class LocationRetriever implements Consumer<Location>, LocationListener
      */
     @Deprecated
     public static void getLocationWithNetwork(long delay_ms, @NonNull LocCb cb, @NonNull Context ctx) {
-        new LocationRetriever(cb, ctx)._getLocation(delay_ms, LocationManager.NETWORK_PROVIDER);
+        LocationManager locMngr = (LocationManager) ctx.getSystemService(Context.LOCATION_SERVICE);
+        if (locMngr.getAllProviders().contains(LocationManager.NETWORK_PROVIDER)
+                && locMngr.isProviderEnabled(LocationManager.NETWORK_PROVIDER) )
+        {
+            // Some ROMs don't have this - LineageOS for example.
+            // Avoid unnecessary reports of missing provider
+            new LocationRetriever(cb, ctx)._getLocation(delay_ms, LocationManager.NETWORK_PROVIDER);
+        }
     }
 
     /** Consumer<Location> method (for API >= 30)

--- a/app/src/main/java/io/github/wandomium/smsloc/LocationRetrieverFgService.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/LocationRetrieverFgService.java
@@ -53,7 +53,6 @@ public class LocationRetrieverFgService extends Service implements LocationRetri
 
     protected String mAddr;
 
-    @SuppressLint("MissingPermission")
     @Override
     public int onStartCommand(Intent intent, int flags, int startId)
     {

--- a/app/src/main/java/io/github/wandomium/smsloc/LocationRetrieverFgService.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/LocationRetrieverFgService.java
@@ -16,7 +16,6 @@
  */
 package io.github.wandomium.smsloc;
 
-import android.annotation.SuppressLint;
 import android.app.ForegroundServiceStartNotAllowedException;
 import android.app.Service;
 import android.content.Context;

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
@@ -133,7 +133,7 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
 
             //we can release the lock before this. If we are not awake, the updates on the
             //app are irrelevant because we are obviously not displaying anything
-            context.sendBroadcast(SmsLoc_Intents.generateIntent(context, addr, broadcastAction));
+            context.sendBroadcast(SmsLoc_Intents.generateIntentWithAddr(context, addr, broadcastAction));
         }
         catch (NumberParseException ignored) {}
         finally {

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
@@ -19,7 +19,6 @@ package io.github.wandomium.smsloc;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Telephony;
 import android.telephony.SmsMessage;
@@ -130,7 +129,7 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
         }
     }
 
-    protected SmsHandler mResponseHandler = (context, addr, params) ->
+    protected final SmsHandler mResponseHandler = (context, addr, params) ->
     {
         final String gpsDataStr = params[0];
 
@@ -167,7 +166,7 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
             SmsLoc_Intents.ACTION_NEW_LOCATION : SmsLoc_Intents.ACTION_RESPONSE_RCVD;
     };
 
-    protected SmsHandler mRequestHandler = (context, addr, params) ->
+    protected final SmsHandler mRequestHandler = (context, addr, params) ->
     {
         final PeopleDataFile PEOPLEDATA = PeopleDataFile.getInstance(context);
         final SmsDayDataFile DAYDATA = SmsDayDataFile.getInstance(context);
@@ -274,7 +273,7 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
     private String _getSmsCountryIso(Context ctx, Intent intent)
     {
         TelephonyManager telService = (TelephonyManager) ctx.getSystemService(Context.TELEPHONY_SERVICE);
-        String smsCountryIso = null;
+        String smsCountryIso;
 
         final int subId = intent.getIntExtra(
                 SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX, SubscriptionManager.INVALID_SUBSCRIPTION_ID);

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsReceiver.java
@@ -19,9 +19,12 @@ package io.github.wandomium.smsloc;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Bundle;
 import android.os.PowerManager;
 import android.provider.Telephony;
 import android.telephony.SmsMessage;
+import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
 import android.util.Log;
 import android.util.SparseArray;
 
@@ -61,43 +64,9 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
 
     private int mCurrentLockId;
 
-    public static void releaseWakeLock(int lockId)
-    {
-        synchronized (INSTANCE_LOCK)
-        {
-//            if (sActiveWakeLocks.contains(lockId)) { //not available in API29, equivalent to below call
-            if(sActiveWakeLocks.indexOfKey(lockId) >= 0) {
-                if (sActiveWakeLocks.get(lockId) != null) {
-                    sActiveWakeLocks.get(lockId).release();
-                }
-                sActiveWakeLocks.remove(lockId);
-            }
-            Log.i(CLASS_TAG, "Wake lock released");
-        }
-    }
-
-    private void _releaseCurrentWakeLock()
-    {
-        releaseWakeLock(mCurrentLockId);
-    }
-    private void _acquireWakeLock(Context context)
-    {
-        synchronized (INSTANCE_LOCK)
-        {
-            mCurrentLockId = sNextId;
-            sNextId++;
-
-            final PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-
-            LogFile.getInstance(context).addLogEntry(
-                String.format("Acquire lock. Device idle: %b", powerManager.isDeviceIdleMode()));
-
-            sActiveWakeLocks.put(
-                mCurrentLockId, powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SmsLoc:SmsReceiver"));
-            sActiveWakeLocks.get(mCurrentLockId).setReferenceCounted(false); //only one fo each wake
-            //sActiveWakeLocks.get(sNextId).acquire(SmsLoc_Settings.getGpsTimeoutInMin(context) * Utils.MIN_2_MS + 500);
-            sActiveWakeLocks.get(mCurrentLockId).acquire((long) SmsLoc_Settings.GPS_TIMEOUT.getInt(context) * Utils.MIN_2_MS + 500);
-        }
+    @FunctionalInterface
+    protected interface SmsHandler {
+        String handle(final Context context, final String addr, String... params);
     }
 
     @Override
@@ -115,27 +84,43 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
             if (sms == null) {
                 continue;
             }
-
-            final String smsCode =
-                    sms.getDisplayMessageBody().substring(0, SmsUtils.CODE_LEN);
-            final String geoData =
-                    sms.getDisplayMessageBody().substring(SmsUtils.CODE_LEN);
-            final String addr    =
-                    SmsUtils.convertToE164PhoneNumFormat(sms.getOriginatingAddress());
-
-            String broadcastAction;
-            switch (smsCode) {
-                case SmsUtils.REQUEST_CODE:  broadcastAction = handleRequest(context, addr); break;
-                case SmsUtils.RESPONSE_CODE: broadcastAction = handleResponse(context, addr, geoData); break;
-                default:
-                    continue;
+            // Address is a must
+            String addr = sms.getOriginatingAddress();
+            if (addr == null) {
+                continue; // Not likely: This should only happen on service msgs or some malformed msg
             }
+            // Get msg
+            final String body = sms.getDisplayMessageBody();
+            if (body == null || body.length() < SmsUtils.CODE_LEN) {
+                continue;
+            }
+            // Is it for us?
+            final SmsHandler smsHandler = switch (body.substring(0, SmsUtils.CODE_LEN)) {
+                case SmsUtils.REQUEST_CODE -> mRequestHandler;
+                case SmsUtils.RESPONSE_CODE -> mResponseHandler;
+                default -> null;
+            };
+            if (smsHandler == null) {
+                continue;
+            }
+
+            // We need addr with country code
+            Log.i(CLASS_TAG, _getSmsCountryIso(context, intent));
+            Log.i(CLASS_TAG, addr);
+            addr = SmsUtils.convertToE164PhoneNumFormat(addr,
+                    (addr.startsWith("+") || addr.startsWith("00")) ? null : _getSmsCountryIso(context, intent));
+
+            // Handle message
+            final String broadcastAction = smsHandler.handle(context, addr, body.substring(SmsUtils.CODE_LEN));
 
             //we can release the lock before this. If we are not awake, the updates on the
             //app are irrelevant because we are obviously not displaying anything
             context.sendBroadcast(SmsLoc_Intents.generateIntentWithAddr(context, addr, broadcastAction));
         }
-        catch (NumberParseException ignored) {}
+        catch (NumberParseException e) {
+            LogFile.getInstance(context).addLogEntry("ERROR - could not handle SMS: " + e.getErrorType());
+            Log.e(CLASS_TAG, e.toString());
+        }
         finally {
             /* Synchronously write, make sure it is stored */
             if (!MainActivity.isCreated()) {
@@ -145,8 +130,10 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
         }
     }
 
-    protected String handleResponse(Context context, final String addr, final String gpsDataStr)
+    protected SmsHandler mResponseHandler = (context, addr, params) ->
     {
+        final String gpsDataStr = params[0];
+
         final PeopleDataFile PEOPLEDATA = PeopleDataFile.getInstance(context);
         final SmsDayDataFile DAYDATA = SmsDayDataFile.getInstance(context);
 
@@ -178,10 +165,10 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
         _releaseCurrentWakeLock();
         return location.dataValid() ?
             SmsLoc_Intents.ACTION_NEW_LOCATION : SmsLoc_Intents.ACTION_RESPONSE_RCVD;
-    }
+    };
 
-    protected String handleRequest(Context context, final String addr) {
-
+    protected SmsHandler mRequestHandler = (context, addr, params) ->
+    {
         final PeopleDataFile PEOPLEDATA = PeopleDataFile.getInstance(context);
         final SmsDayDataFile DAYDATA = SmsDayDataFile.getInstance(context);
 
@@ -237,5 +224,69 @@ public class SmsReceiver extends BroadcastReceiver//WakefulBroadcastReceiver
             _releaseCurrentWakeLock();
             return SmsLoc_Intents.ACTION_NOT_WHITELISTED;
         }
+    };
+
+    public static void releaseWakeLock(int lockId)
+    {
+        synchronized (INSTANCE_LOCK)
+        {
+//            if (sActiveWakeLocks.contains(lockId)) { //not available in API29, equivalent to below call
+            if(sActiveWakeLocks.indexOfKey(lockId) >= 0) {
+                if (sActiveWakeLocks.get(lockId) != null) {
+                    sActiveWakeLocks.get(lockId).release();
+                }
+                sActiveWakeLocks.remove(lockId);
+            }
+            Log.i(CLASS_TAG, "Wake lock released");
+        }
+    }
+
+    private void _releaseCurrentWakeLock()
+    {
+        releaseWakeLock(mCurrentLockId);
+    }
+
+    private void _acquireWakeLock(Context context)
+    {
+        synchronized (INSTANCE_LOCK)
+        {
+            mCurrentLockId = sNextId;
+            sNextId++;
+
+            final PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+
+            LogFile.getInstance(context).addLogEntry("Acquire lock. Device idle: " + powerManager.isDeviceIdleMode());
+
+            sActiveWakeLocks.put(
+                    mCurrentLockId, powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "SmsLoc:SmsReceiver"));
+            sActiveWakeLocks.get(mCurrentLockId).setReferenceCounted(false); //only one fo each wake
+            //sActiveWakeLocks.get(sNextId).acquire(SmsLoc_Settings.getGpsTimeoutInMin(context) * Utils.MIN_2_MS + 500);
+            sActiveWakeLocks.get(mCurrentLockId).acquire((long) SmsLoc_Settings.GPS_TIMEOUT.getInt(context) * Utils.MIN_2_MS + 500);
+        }
+    }
+
+    /**
+     * SmsMessage.getOriginatingAddress() does not always include country code
+     * We need to be able to handle dual SIM operation
+     * Some extra gymnastics are required to get the country code if we are not the
+     * default messaging app and/or do not have READ_PHONE_STATE permissions
+     */
+    private String _getSmsCountryIso(Context ctx, Intent intent)
+    {
+        TelephonyManager telService = (TelephonyManager) ctx.getSystemService(Context.TELEPHONY_SERVICE);
+        String smsCountryIso = null;
+
+        final int subId = intent.getIntExtra(
+                SubscriptionManager.EXTRA_SUBSCRIPTION_INDEX, SubscriptionManager.INVALID_SUBSCRIPTION_ID);
+        if (subId == SubscriptionManager.INVALID_SUBSCRIPTION_ID) {
+            //fallback to default
+            smsCountryIso = telService.getSimCountryIso();
+            LogFile.getInstance(ctx).addLogEntry("Could not determine country code for SMS, using default " + smsCountryIso);
+        }
+        else {
+            smsCountryIso = telService.createForSubscriptionId(subId).getSimCountryIso();
+        }
+
+        return smsCountryIso;
     }
 }

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsSentReceiver.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsSentReceiver.java
@@ -1,0 +1,37 @@
+package io.github.wandomium.smsloc;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.telephony.SmsManager;
+import android.widget.Toast;
+
+import io.github.wandomium.smsloc.data.file.LogFile;
+
+public class SmsSentReceiver extends BroadcastReceiver {
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        final String errStr = switch (getResultCode()) {
+            case Activity.RESULT_OK -> "SMS Sent";
+            case SmsManager.RESULT_ERROR_GENERIC_FAILURE -> "ERROR: Generic failure sending SMS";
+            case SmsManager.RESULT_ERROR_NO_SERVICE -> "ERROR: Cound not send SMS - No service available";
+            case SmsManager.RESULT_ERROR_NULL_PDU -> "ERROR: Cound not send SMS - Null PDU error";
+            case SmsManager.RESULT_ERROR_RADIO_OFF -> "ERROR: Cound not send SMS - Radio off";
+            default -> "SMS send status unknown";
+        };
+
+        LogFile.getInstance(context).addLogEntry(errStr);
+        if (MainActivity.isCreated()) {
+            Toast.makeText(context.getApplicationContext(), errStr, Toast.LENGTH_LONG).show();
+        }
+    }
+
+    public static PendingIntent getPendingIntent(Context ctx)
+    {
+        return PendingIntent.getBroadcast(ctx, 0,
+                    new Intent(ctx, SmsSentReceiver.class),
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+    }
+}

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
@@ -18,13 +18,9 @@ package io.github.wandomium.smsloc;
 
 import android.Manifest;
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.os.Build;
 import android.telephony.SmsManager;
-import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
-import android.telephony.TelephonyManager;
-import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 
@@ -35,7 +31,6 @@ import com.google.i18n.phonenumbers.Phonenumber;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
 import java.util.Locale;
-import java.util.Objects;
 
 import io.github.wandomium.smsloc.data.file.LogFile;
 import io.github.wandomium.smsloc.defs.SmsLoc_Settings;
@@ -116,7 +111,7 @@ public class SmsUtils
     public static String convertToE164PhoneNumFormat(String phoneNumStr, String defaultRegion)
             throws NumberParseException
     {
-        PhoneNumberUtil pnumberUtil = PhoneNumberUtil.getInstance();
+        PhoneNumberUtil pNumberUtil = PhoneNumberUtil.getInstance();
         Phonenumber.PhoneNumber phoneNumber;
 
         // If country code starts with 00 and not + replace with +
@@ -128,7 +123,7 @@ public class SmsUtils
             if (defaultRegion != null) {
                 defaultRegion = defaultRegion.toUpperCase(Locale.ROOT);
             }
-            phoneNumber = pnumberUtil.parse(phoneNumStr, defaultRegion);
+            phoneNumber = pNumberUtil.parse(phoneNumStr, defaultRegion);
         }
         catch (NumberParseException e) {
             if (e.getErrorType() == NumberParseException.ErrorType.INVALID_COUNTRY_CODE) {
@@ -141,10 +136,10 @@ public class SmsUtils
 
 //        // Check if it is a mobile number, because we need to be able to send SMS
 //        // Relax this check. A lot of issues reported with rejected mobile numbers
-//        if (pnumberUtil.getNumberType(phoneNumber) != PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE) {
+//        if (pNumberUtil.getNumberType(phoneNumber) != PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE) {
 //            throw new NumberParseException(NumberParseException.ErrorType.NOT_A_NUMBER, "Not a mobile number, required for SMS.");
 //        }
 
-        return pnumberUtil.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
+        return pNumberUtil.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
     }
 }

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
@@ -18,9 +18,13 @@ package io.github.wandomium.smsloc;
 
 import android.Manifest;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.telephony.SmsManager;
+import android.telephony.SubscriptionInfo;
 import android.telephony.SubscriptionManager;
+import android.telephony.TelephonyManager;
+import android.util.Log;
 
 import androidx.core.app.ActivityCompat;
 
@@ -30,6 +34,7 @@ import com.google.i18n.phonenumbers.Phonenumber;
 
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 
+import java.util.Locale;
 import java.util.Objects;
 
 import io.github.wandomium.smsloc.data.file.LogFile;
@@ -37,6 +42,8 @@ import io.github.wandomium.smsloc.defs.SmsLoc_Settings;
 
 public class SmsUtils
 {
+    private static final String CLASS_TAG = SmsUtils.class.getSimpleName();
+
     public static final String REQUEST_CODE = "Loc?";
     public static final String RESPONSE_CODE = "Loc:";
     public static final int CODE_LEN = 4;
@@ -98,8 +105,15 @@ public class SmsUtils
         smsManager.sendTextMessage(addr, null, msg, null, null);
     }
 
-    //TODO fina a place for this
-    public static String convertToE164PhoneNumFormat(String phoneNumStr)
+    /**
+     * WHEN ADDING NEW PERSON: Don't even try with SIM country ISO
+     * if we pass null, then it will fail if the number does not have a
+     * country code included. Which is the safer/easier option in multi-sim support
+     * *
+     * WHEN CALLING FROM SmsReceiver: Needs default sim country iso because SMS addr can have none
+     * and it will fail
+     */
+    public static String convertToE164PhoneNumFormat(String phoneNumStr, String defaultRegion)
             throws NumberParseException
     {
         PhoneNumberUtil pnumberUtil = PhoneNumberUtil.getInstance();
@@ -111,11 +125,10 @@ public class SmsUtils
         }
 
         try {
-            /* Don't even try with SIM country ISO
-             * if we pass null, then it will fail if the number does not have a
-             * country code included. Which is the safer/easier option in multi-sim support
-             */
-            phoneNumber = pnumberUtil.parse(phoneNumStr, null);
+            if (defaultRegion != null) {
+                defaultRegion = defaultRegion.toUpperCase(Locale.ROOT);
+            }
+            phoneNumber = pnumberUtil.parse(phoneNumStr, defaultRegion);
         }
         catch (NumberParseException e) {
             if (e.getErrorType() == NumberParseException.ErrorType.INVALID_COUNTRY_CODE) {
@@ -126,11 +139,11 @@ public class SmsUtils
             }
         }
 
-        // Check if it is a mobile number, because we need to be able to send SMS
-        // Relax this check. A lot of issues reported with rejected mobile numbers
-        if (pnumberUtil.getNumberType(phoneNumber) != PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE) {
-            throw new NumberParseException(NumberParseException.ErrorType.NOT_A_NUMBER, "Not a mobile number, required for SMS.");
-        }
+//        // Check if it is a mobile number, because we need to be able to send SMS
+//        // Relax this check. A lot of issues reported with rejected mobile numbers
+//        if (pnumberUtil.getNumberType(phoneNumber) != PhoneNumberUtil.PhoneNumberType.FIXED_LINE_OR_MOBILE) {
+//            throw new NumberParseException(NumberParseException.ErrorType.NOT_A_NUMBER, "Not a mobile number, required for SMS.");
+//        }
 
         return pnumberUtil.format(phoneNumber, PhoneNumberUtil.PhoneNumberFormat.E164);
     }

--- a/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/SmsUtils.java
@@ -102,7 +102,7 @@ public class SmsUtils
             throw new IllegalArgumentException("Could not send sms: Invalid SIM Id");
         }
 
-        smsManager.sendTextMessage(addr, null, msg, null, null);
+        smsManager.sendTextMessage(addr, null, msg, SmsSentReceiver.getPendingIntent(context), null);
     }
 
     /**

--- a/app/src/main/java/io/github/wandomium/smsloc/data/file/LogFile.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/data/file/LogFile.java
@@ -20,6 +20,7 @@ import android.content.Context;
 
 import io.github.wandomium.smsloc.data.base.BaseFile;
 import io.github.wandomium.smsloc.defs.SmsLoc_Common;
+import io.github.wandomium.smsloc.defs.SmsLoc_Intents;
 import io.github.wandomium.smsloc.toolbox.Utils;
 
 import java.io.IOException;
@@ -71,7 +72,7 @@ public class LogFile extends BaseFile
         Files.write(mFilePath, mLogEntries);
     }
 
-    public void addLogEntry(String msg)
+    public void addLogEntry(final String msg)
     {
         synchronized (LOCK)
         {
@@ -80,6 +81,8 @@ public class LogFile extends BaseFile
             mDiskUnsynced = true;
         }
         writeFileAsync();
+
+        mAppContext.sendBroadcast(SmsLoc_Intents.generateSimpleIntent(mAppContext, SmsLoc_Intents.ACTION_LOG_UPDATED));
     }
 
     public final ArrayList<String> readLog()

--- a/app/src/main/java/io/github/wandomium/smsloc/defs/SmsLoc_Intents.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/defs/SmsLoc_Intents.java
@@ -46,12 +46,18 @@ public class SmsLoc_Intents
     public static final String ACTION_ERROR              = BuildConfig.APPLICATION_ID + ".intent.error";
 
     //TODO update this
-    public static android.content.Intent generateIntent(Context ctx, final String addr, final String action)
+    public static android.content.Intent generateIntentWithAddr(Context ctx, final String addr, final String action)
     {
         android.content.Intent intent = new android.content.Intent(action);
         intent.setPackage(ctx.getPackageName());
         intent.putExtra(EXTRA_ADDR, addr);
 
+        return intent;
+    }
+    public static android.content.Intent generateSimpleIntent(Context ctx, final String action)
+    {
+        android.content.Intent intent = new android.content.Intent(action);
+        intent.setPackage(ctx.getPackageName());
         return intent;
     }
     public static android.content.Intent generateErrorIntent(Context ctx, final String msg)

--- a/app/src/main/java/io/github/wandomium/smsloc/defs/SmsLoc_Intents.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/defs/SmsLoc_Intents.java
@@ -19,7 +19,10 @@ package io.github.wandomium.smsloc.defs;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Build;
+
+import java.util.ArrayList;
 
 import io.github.wandomium.smsloc.BuildConfig;
 
@@ -60,40 +63,72 @@ public class SmsLoc_Intents
         return intent;
     }
     /** @noinspection SpellCheckingInspection*/
-    public static Intent generateBgAutostartIntent()
+    public static Intent generateBgAutostartIntent(Context ctx)
     {
-        Intent intent = new Intent();
-        String manufacturer = Build.MANUFACTURER.toLowerCase();
+        ArrayList<ComponentName> candidates = new ArrayList<>();
 
-        switch (manufacturer) {
+        switch (Build.MANUFACTURER.toLowerCase()) {
             case "xiaomi":
-                intent.setComponent(new ComponentName("com.miui.securitycenter",
+            case "redmi":
+            case "poco":
+                candidates.add(new ComponentName("com.miui.securitycenter",
                         "com.miui.permcenter.autostart.AutoStartManagementActivity"));
                 break;
+
             case "oppo":
-                intent.setComponent(new ComponentName("com.coloros.safecenter",
+            case "realme":
+                candidates.add(new ComponentName("com.coloros.safecenter",
                         "com.coloros.safecenter.permission.startup.StartupAppListActivity"));
+                candidates.add(new ComponentName("com.coloros.safecenter",
+                        "com.coloros.safecenter.startupapp.StartupAppListActivity"));
+                candidates.add(new ComponentName("com.oppo.safe",
+                        "com.oppo.safe.permission.startup.StartupAppListActivity"));
                 break;
+
             case "vivo":
-                intent.setComponent(new ComponentName("com.iqoo.secure",
+            case "iqoo":
+                candidates.add(new ComponentName("com.vivo.permissionmanager",
+                        "com.vivo.permissionmanager.activity.BgStartUpManagerActivity"));
+                candidates.add(new ComponentName("com.iqoo.secure",
                         "com.iqoo.secure.ui.phoneoptimize.AddWhiteListActivity"));
+                candidates.add(new ComponentName("com.iqoo.secure",
+                        "com.iqoo.secure.ui.phoneoptimize.BgStartUpManager"));
                 break;
-            case "letv":
-                intent.setComponent(new ComponentName("com.letv.android.letvsafe",
-                        "com.letv.android.letvsafe.AutobootManageActivity"));
-                break;
-            case "asus":
-                intent.setComponent(new ComponentName("com.asus.mobilemanager",
-                        "com.asus.mobilemanager.entry.FunctionActivity"));
-                break;
+
             case "huawei":
-                intent.setComponent(new ComponentName("com.huawei.systemmanager",
+            case "honor":
+                candidates.add(new ComponentName("com.huawei.systemmanager",
+                        "com.huawei.systemmanager.optimize.process.ProtectActivity"));
+                candidates.add(new ComponentName("com.huawei.systemmanager",
+                        "com.huawei.systemmanager.appcontrol.activity.StartupAppControlActivity"));
+                candidates.add(new ComponentName("com.huawei.systemmanager",
                         "com.huawei.systemmanager.startupmgr.ui.StartupNormalAppListActivity"));
                 break;
-            default:
-                intent = null;
+
+            case "letv":
+                candidates.add(new ComponentName("com.letv.android.letvsafe",
+                        "com.letv.android.letvsafe.AutobootManageActivity"));
+                break;
+
+            case "asus":
+                candidates.add(new ComponentName("com.asus.mobilemanager",
+                        "com.asus.mobilemanager.entry.FunctionActivity"));
+                candidates.add(new ComponentName("com.asus.mobilemanager",
+                        "com.asus.mobilemanager.powersaver.PowerSaverSettings"));
                 break;
         }
-        return intent;
+
+        for (ComponentName component : candidates) {
+            Intent intent = new Intent();
+            intent.setComponent(component);
+            // It is possible that a custom ROM was flashed
+            // Example is: LineageOS
+            if (ctx.getPackageManager()
+                    .resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null) {
+                return intent;
+            }
+        }
+
+        return null;
     }
 }

--- a/app/src/main/java/io/github/wandomium/smsloc/ui/dialogs/PersonActionDialogFragment.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/ui/dialogs/PersonActionDialogFragment.java
@@ -101,7 +101,7 @@ public class PersonActionDialogFragment extends DialogFragment
                             final Context ctx = PersonActionDialogFragment.this.requireContext();
                             LOGDATA.addLogEntry("Removing person: " + displayName);
                             PEOPLEDATA.removeDataEntry(mAddr); //no need to remove day data, we store unlisted people anyway
-                            ctx.sendBroadcast(SmsLoc_Intents.generateIntent(ctx, mAddr, SmsLoc_Intents.ACTION_PERSON_REMOVED));
+                            ctx.sendBroadcast(SmsLoc_Intents.generateIntentWithAddr(ctx, mAddr, SmsLoc_Intents.ACTION_PERSON_REMOVED));
                             break;
 
                         case NAVIGATE:
@@ -143,7 +143,7 @@ public class PersonActionDialogFragment extends DialogFragment
         DAYDATA.writeFileAsync();
 
         requireContext().sendBroadcast(
-            SmsLoc_Intents.generateIntent(requireContext(), mAddr, SmsLoc_Intents.ACTION_REQUEST_SENT));
+            SmsLoc_Intents.generateIntentWithAddr(requireContext(), mAddr, SmsLoc_Intents.ACTION_REQUEST_SENT));
     }
 
     private boolean _navigateTo()

--- a/app/src/main/java/io/github/wandomium/smsloc/ui/dialogs/SimpleDialogs.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/ui/dialogs/SimpleDialogs.java
@@ -112,7 +112,7 @@ public class SimpleDialogs {
 
     private static void _showBgAutostartAlert(MainActivity activity)
     {
-        final Intent bgAutostartIntent = SmsLoc_Intents.generateBgAutostartIntent();
+        final Intent bgAutostartIntent = SmsLoc_Intents.generateBgAutostartIntent(activity);
         if (bgAutostartIntent != null) {
             // if it is not null it means we are on a custom rom that we probably know how to handle
             // we open the settings but set flag to ignore so the user is not prompted on every boot

--- a/app/src/main/java/io/github/wandomium/smsloc/ui/main/PeopleFragment.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/ui/main/PeopleFragment.java
@@ -241,7 +241,7 @@ public class PeopleFragment extends ABaseFragment implements LocationRetriever.L
 
     private void _addPerson(@NonNull final String addrIn, @NonNull String name) throws NumberParseException, IllegalArgumentException
     {
-        final String addr = SmsUtils.convertToE164PhoneNumFormat(addrIn);
+        final String addr = SmsUtils.convertToE164PhoneNumFormat(addrIn, null);
 
         final PeopleDataFile PEOPLEDATA = PeopleDataFile.getInstance(requireContext());
         if (PEOPLEDATA.containsId(addr)) {

--- a/app/src/main/java/io/github/wandomium/smsloc/ui/main/PeopleFragment.java
+++ b/app/src/main/java/io/github/wandomium/smsloc/ui/main/PeopleFragment.java
@@ -263,7 +263,7 @@ public class PeopleFragment extends ABaseFragment implements LocationRetriever.L
 
         _listAdapter().add(addr);
         LogFile.getInstance(requireContext()).addLogEntry("Added contact: " + name);
-        requireContext().sendBroadcast(SmsLoc_Intents.generateIntent(requireContext(), addr, SmsLoc_Intents.ACTION_NEW_PERSON));
+        requireContext().sendBroadcast(SmsLoc_Intents.generateIntentWithAddr(requireContext(), addr, SmsLoc_Intents.ACTION_NEW_PERSON));
     }
 
 

--- a/metadata/en-US/changelogs/116.txt
+++ b/metadata/en-US/changelogs/116.txt
@@ -1,3 +1,7 @@
 [x] Relaxed mobile number check to MOBILE_OR_LANDLINE due to too many false negatives (issue #10)
 [x] Now accepts '00' and '+' as country code prefix. Still requires country code! (issue #10)
 [x] Updated list of background autostart restrictions on custom ROMS, checks if app exists to avoid faulty settings open on non-stock ROMs (eex. LineageOS) (see #14)
+[] Added sms sent feedback
+Bugfixes:
+[x] Refresh log list on new log entry (do not wait for tab reload)
+[] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS

--- a/metadata/en-US/changelogs/116.txt
+++ b/metadata/en-US/changelogs/116.txt
@@ -1,2 +1,3 @@
 [x] Relaxed mobile number check to MOBILE_OR_LANDLINE due to too many false negatives (issue #10)
 [x] Now accepts '00' and '+' as country code prefix. Still requires country code! (issue #10)
+[x] Updated list of background autostart restrictions on custom ROMS, checks if app exists to avoid faulty settings open on non-stock ROMs (eex. LineageOS) (see #14)

--- a/metadata/en-US/changelogs/116.txt
+++ b/metadata/en-US/changelogs/116.txt
@@ -5,3 +5,4 @@
 Bugfixes:
 [x] Refresh log list on new log entry (do not wait for tab reload)
 [] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
+[X] If received SMS does not include country code, SMS response fails (issue #15)

--- a/metadata/en-US/changelogs/116.txt
+++ b/metadata/en-US/changelogs/116.txt
@@ -1,8 +1,8 @@
-[x] Relaxed mobile number check to MOBILE_OR_LANDLINE due to too many false negatives (issue #10)
 [x] Now accepts '00' and '+' as country code prefix. Still requires country code! (issue #10)
 [x] Updated list of background autostart restrictions on custom ROMS, checks if app exists to avoid faulty settings open on non-stock ROMs (eex. LineageOS) (see #14)
-[] Added sms sent feedback
+[x] Added sms sent feedback
 Bugfixes:
 [x] Refresh log list on new log entry (do not wait for tab reload)
 [] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
-[X] If received SMS does not include country code, SMS response fails (issue #15)
+[x] If received SMS does not include country code, SMS response fails (issue #15)
+[x] Removed check if it is a mobile number due to too many false negatives (issue #10). added sms sent feedback as backup

--- a/metadata/en-US/changelogs/116.txt
+++ b/metadata/en-US/changelogs/116.txt
@@ -1,0 +1,2 @@
+[x] Relaxed mobile number check to MOBILE_OR_LANDLINE due to too many false negatives (issue #10)
+[x] Now accepts '00' and '+' as country code prefix. Still requires country code! (issue #10)

--- a/metadata/en-US/changelogs/120.txt
+++ b/metadata/en-US/changelogs/120.txt
@@ -5,4 +5,4 @@ Bugfixes:
 [x] Refresh log list on new log entry (do not wait for tab reload)
 [] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
 [x] If received SMS does not include country code, SMS response fails (issue #15)
-[x] Removed check if it is a mobile number due to too many false negatives (issue #10). added sms sent feedback as backup
+[x] Removed check if it is a mobile number due to too many false negatives (issue #10). added sms sent feedback as backup   

--- a/metadata/en-US/changelogs/120.txt
+++ b/metadata/en-US/changelogs/120.txt
@@ -3,6 +3,6 @@
 [x] Added sms sent feedback
 Bugfixes:
 [x] Refresh log list on new log entry (do not wait for tab reload)
-[] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
+[x] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
 [x] If received SMS does not include country code, SMS response fails (issue #15)
 [x] Removed check if it is a mobile number due to too many false negatives (issue #10). added sms sent feedback as backup   


### PR DESCRIPTION
[x] Now accepts '00' and '+' as country code prefix. Still requires country code! (issue #10)
[x] Updated list of background autostart restrictions on custom ROMS, checks if app exists to avoid faulty settings open on non-stock ROMs (eex. LineageOS) (see #14)
[x] Added sms sent feedback
Bugfixes:
[x] Refresh log list on new log entry (do not wait for tab reload)
[x] Do not keep on repeating 'no GPS provider network found errors' - manifests on LineageOS
[x] If received SMS does not include country code, SMS response fails (issue #15)
[x] Removed check if it is a mobile number due to too many false negatives (issue #10). added sms sent feedback as backup   